### PR TITLE
Changed version to 3.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.2'
 
 # This file defines two services: The db service and the web service.
 services:
@@ -27,6 +27,7 @@ services:
       - POSTGRES_DB:${DATABASE_NAME}
       - POSTGRES_PASSWORD:${DATABASE_PASSWORD}
       - POSTGRES_HOST:${DATABASE_HOST}
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - ./pgdata:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
Changed compose version to 3.3
set POSTGRES_HOST_AUTH_METHOD  to trust to allow access to postgres port though not recommended
Can be replaced with `docker run -e POSTGRES_PASSWORD=<your_password>`